### PR TITLE
 fix(service): Create audit records when arrive multiple entities by broker notification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
+      - name: Build Cache Docker Image
+        run: docker build --file Dockerfile --build-arg SKIP_TESTS=true --tag desmos-api .
+
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main/java/es/in2/desmos/domain/services/api/impl/AuditRecordServiceImpl.java
+++ b/src/main/java/es/in2/desmos/domain/services/api/impl/AuditRecordServiceImpl.java
@@ -84,6 +84,7 @@ public class AuditRecordServiceImpl implements AuditRecordService {
                         log.warn("ProcessID: {} - Error building and saving audit record: {}", processId, e.getMessage());
                         return Mono.error(e);
                     }
+
                     return auditRecordRepository.save(auditRecord)
                             .doOnSuccess(unused -> log.info("ProcessID: {} - Audit record saved successfully. - Status: {}", processId, status))
                             .then();

--- a/src/main/java/es/in2/desmos/domain/services/broker/impl/BrokerListenerServiceImpl.java
+++ b/src/main/java/es/in2/desmos/domain/services/broker/impl/BrokerListenerServiceImpl.java
@@ -46,7 +46,8 @@ public class BrokerListenerServiceImpl implements BrokerListenerService {
     public Mono<Void> processBrokerNotification(String processId, BrokerNotification brokerNotification) {
         log.info("ProcessID: {} - Processing Broker Notification...", processId);
         // Validate BrokerNotification is not null and has data
-        return getDataFromBrokerNotification(brokerNotification)
+        return Mono.just(brokerNotification.data())
+                .flatMapIterable(dataList -> dataList)
                 // Validate if BrokerNotification is from an external source or self-generated
                 .flatMap(dataMap -> isBrokerNotificationFromExternalSource(processId, dataMap))
                 // Create and AuditRecord with status RECEIVED
@@ -67,12 +68,6 @@ public class BrokerListenerServiceImpl implements BrokerListenerService {
                         log.error("ProcessID: {} - Error processing Broker Notification: {}", processId, throwable.getMessage());
                     }
                 });
-    }
-
-    private Mono<Map<String, Object>> getDataFromBrokerNotification(BrokerNotification brokerNotification) {
-        //Get data from brokerNotification
-        Map<String, Object> dataMap = brokerNotification.data().get(0);
-        return Mono.just(dataMap);
     }
 
     private Mono<Map<String, Object>> isBrokerNotificationFromExternalSource(String processId, Map<String, Object> dataMap) {

--- a/src/test/java/es/in2/desmos/it/domain/services/ScorpioAdapterIT.java
+++ b/src/test/java/es/in2/desmos/it/domain/services/ScorpioAdapterIT.java
@@ -121,6 +121,11 @@ class ScorpioAdapterIT {
                     }
                 })
                 .verifyComplete();
+
+        scorpioAdapter.deleteEntityById("0", MVEntity4DataNegotiationMother.sampleScorpio1().id());
+        scorpioAdapter.deleteEntityById("0", MVEntity4DataNegotiationMother.sampleScorpio2().id());
+        scorpioAdapter.deleteEntityById("0", MVEntity4DataNegotiationMother.sampleScorpio3().id());
+        scorpioAdapter.deleteEntityById("0", MVEntity4DataNegotiationMother.sampleScorpio4().id());
     }
 
     @Test

--- a/src/test/java/es/in2/desmos/objectmothers/AuditRecordMother.java
+++ b/src/test/java/es/in2/desmos/objectmothers/AuditRecordMother.java
@@ -10,6 +10,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public final class AuditRecordMother {
@@ -32,6 +33,25 @@ public final class AuditRecordMother {
                 .hash("")
                 .hashLink("")
                 .newTransaction(true)
+                .build();
+    }
+
+    public static AuditRecord createAuditRecordFromDataMap(String processId, Map<String, Object> dataMap) {
+
+        return AuditRecord.builder()
+                .id(UUID.randomUUID())
+                .processId(processId)
+                .createdAt(Timestamp.from(Instant.now()))
+                .entityId(dataMap.get("id").toString())
+                .entityType(dataMap.get("type").toString())
+                .entityHash("")
+                .entityHashLink("")
+                .dataLocation("")
+                .status(AuditRecordStatus.RECEIVED)
+                .trader(AuditRecordTrader.PRODUCER)
+                .hash("")
+                .hashLink("")
+                .newTransaction(false)
                 .build();
     }
 

--- a/src/test/java/es/in2/desmos/objectmothers/BrokerNotificationMother.java
+++ b/src/test/java/es/in2/desmos/objectmothers/BrokerNotificationMother.java
@@ -1,0 +1,36 @@
+package es.in2.desmos.objectmothers;
+
+import es.in2.desmos.domain.models.BrokerNotification;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public final class BrokerNotificationMother {
+    private BrokerNotificationMother() {
+    }
+
+    public static BrokerNotification withDataArray() {
+        Map<String, Object> productOffering1 = Map.of(
+                "id", "urn:ngsi-ld:ProductOffering:122355255",
+                "type", "ProductOffering",
+                "description", Map.of("type", "Property", "value", "Example of a Product offering for cloud services suite"),
+                "notifiedAt", "2024-04-10T11:33:43.807000Z"
+        );
+
+        Map<String, Object> productOffering2 = Map.of(
+                "id", "urn:ngsi-ld:ProductOffering:552553221",
+                "type", "ProductOffering",
+                "description", Map.of("type", "Property", "value", "Another example of a Product offering for cloud services suite"), // Cambio en la descripción
+                "notifiedAt", "2024-04-10T11:33:43.807000Z"
+        );
+
+        return BrokerNotification.builder()
+                .id("notification:-5106976853901020699")
+                .type("Notification")
+                .data(List.of(productOffering1, productOffering2))
+                .subscriptionId("urn:ngsi-ld:Subscription:122355255")
+                .notifiedAt(Instant.now().toString())
+                .build();
+    }
+}

--- a/src/test/java/es/in2/desmos/objectmothers/EnqueueEventMother.java
+++ b/src/test/java/es/in2/desmos/objectmothers/EnqueueEventMother.java
@@ -1,0 +1,18 @@
+package es.in2.desmos.objectmothers;
+
+import es.in2.desmos.domain.models.EventQueue;
+import es.in2.desmos.domain.models.EventQueuePriority;
+
+import java.util.List;
+
+public final class EnqueueEventMother {
+    private EnqueueEventMother() {
+    }
+
+    public static EventQueue sample(List<Object> events) {
+        return EventQueue.builder()
+                .event(events)
+                .priority(EventQueuePriority.MEDIUM)
+                .build();
+    }
+}


### PR DESCRIPTION
Fix an issue where audit records were not being properly created when multiple entities arrived in a single request through broker notification.
The update ensures that whenever a broker notification send multiple entities in a single request, the system correctly do the process for each entity.